### PR TITLE
Remove invalid trailing comma in example son

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Homebridge plugin to control LG webOS TV in HomeKit as TV service. Tested with L
                 },
                 {
                     "name": "Netflix",
-                    "reference": "netflix",
+                    "reference": "netflix"
                 },
                 {
                     "name": "YouTube",


### PR DESCRIPTION
This PR removes a trailing comma which causes the example JSON to be invalid. 