### PR TITLE
Fix missing slash

### DIFF
--- a/src/constans.json
+++ b/src/constans.json
@@ -40,7 +40,7 @@
         "GetSystemInfo": "ssap://system/getSystemInfo",
         "GetSoftwareInfo": "ssap://com.webos.service.update/getCurrentSWInformation",
         "GetInstalledApps": "ssap://com.webos.applicationManager/listApps",
-        "GetChannelList": "ssap:/tv/getChannelList",
+        "GetChannelList": "ssap://tv/getChannelList",
         "GetPowerState": "ssap://com.webos.service.tvpower/power/getPowerState",
         "GetForegroundAppInfo": "ssap://com.webos.applicationManager/getForegroundAppInfo",
         "GetCurrentChannel": "ssap://tv/getCurrentChannel",


### PR DESCRIPTION
This PR fixes a missing slash in `constants.json`.

Without this, I was unable to get the list of TV channels in the directory.