### PR TITLE
fix: increase default frame size for received socket messages

### DIFF
--- a/src/lgwebsocket.js
+++ b/src/lgwebsocket.js
@@ -10,7 +10,8 @@ const SOCKET_OPTIONS = {
     keepalive: true,
     keepaliveInterval: 5000,
     keepaliveGracePeriod: 3000,
-    dropConnectionOnKeepaliveTimeout: true
+    dropConnectionOnKeepaliveTimeout: true,
+    maxReceivedFrameSize: 4000000,
 };
 
 class LGTV extends EventEmitter {


### PR DESCRIPTION
Fixes #153 

On a webOS TV the current payload is about 2.4MB, so I set a higher value with more buffer. Potentially an option to make this configurable in the future.