### PR TITLE
fix displayOrder crash

### DIFF
--- a/src/lgwebosdevice.js
+++ b/src/lgwebosdevice.js
@@ -1681,7 +1681,7 @@ class LgWebOsDevice extends EventEmitter {
             };
 
             //sort inputs list
-            await this.displayOrder();
+            this.televisionService ? await this.displayOrder() : false;
 
             return accessory;
         } catch (error) {


### PR DESCRIPTION
This should fix the following error which causes the service to crash completely:

`[2/8/2025, 10:34:49 PM] [homebridge-lgwebos-tv] Device: DEVICEIP Living Room Projector, Error: Start error: Error: Error: Display order error: TypeError: Cannot read properties of undefined (reading 'setCharacteristic'), trying again.
`

Tested on the currently latest release.