### PR TITLE
refactor: use TCP port check instead of ICMP ping

### DIFF
--- a/src/lgwebossocket.js
+++ b/src/lgwebossocket.js
@@ -66,7 +66,7 @@ class LgWebOsSocket extends EventEmitter {
                     if (this.socketConnected || this.connecting) return;
                     if (this.logDebug) this.emit('debug', `Plugin send heartbeat to TV`);
 
-                    const state = await this.functions.ping(this.host);
+                    const state = await this.functions.ping(this.host, this.webSocketPort);
                     if (!state.online) {
                         return;
                     }


### PR DESCRIPTION
## Problem

When the TV goes into deep sleep and wakes up again, the plugin fails to reconnect in restricted environments (e.g., Docker containers).

The reconnection logic uses ICMP ping to check if the TV is online:
```shell
# without sudo
$ ping -c 1 192.168.50.102
ping: socket: Operation not permitted

# with sudo
$ sudo ping -c 1 192.168.50.102              
Password: 
PING 192.168.50.102 (192.168.50.102) 56(84) bytes of data.
64 bytes from 192.168.50.102: icmp_seq=1 ttl=64 time=0.227 ms

--- 192.168.50.102 ping statistics ---
1 packets transmitted, 1 received, 0% packet loss, time 0ms
rtt min/avg/max/mdev = 0.227/0.227/0.227/0.000 ms
```


ICMP ping requires raw socket access, which needs root/sudo privileges that are often unavailable in containerized environments.

## Background

In commit [ca77df9](https://github.com/grzegorz914/homebridge-lgwebos-tv/commit/ca77df994d7d8038de9e40d350044bdd2094c9f8), the `tcp-ping` package was removed and replaced with ICMP ping via shell command to reduce dependencies. While this simplified the codebase, it introduced a regression for users running Homebridge in Docker or other restricted environments where ICMP requires elevated privileges.

| | `tcp-ping` (before) | ICMP `ping` (current) |
|---|---|---|
| Method | TCP port check | ICMP Echo Request |
| Privileges | User-level ✅ | Root required ❌ |
| Docker | Works ✅ | `Operation not permitted` ❌ |

## Solution

Replace ICMP ping with TCP port check using Node.js native `net.createConnection()`. This approach:

- ✅ Works without elevated privileges
- ✅ No external dependencies (unlike the removed `tcp-ping` package)
- ✅ No external process spawn required
- ✅ More accurate — directly checks if the WebSocket port (3000/3001) is accessible
- ✅ Cross-platform compatible (Windows, Linux, macOS, Docker)

This effectively restores the TCP-based connectivity check behavior that existed before the `tcp-ping` removal, but implemented natively without any external packages.

## Changes

- **`src/functions.js`**: Replaced ICMP ping command execution with TCP socket connection check
- **`src/lgwebossocket.js`**: Pass WebSocket port to ping function

## Testing

Tested reconnection after TV deep sleep in Docker environment — plugin now successfully reconnects when TV powers on.