### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,5 +1,10 @@
 name: Mark stale issues and pull requests
 
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
 on:
   schedule:
     - cron: '0 0 * * *'  # Runs daily at midnight (UTC)


### PR DESCRIPTION
Potential fix for [https://github.com/grzegorz914/homebridge-lgwebos-tv/security/code-scanning/1](https://github.com/grzegorz914/homebridge-lgwebos-tv/security/code-scanning/1)

In general, the fix is to add an explicit `permissions` block to the workflow, granting only the scopes required for the stale action to function. For this workflow, it needs to comment on and close issues/PRs and to apply labels, which requires `issues: write` and `pull-requests: write`. Many stale workflows also require `contents: write` for some repository interactions, and CodeQL’s recommended minimal starting point is `contents: write, issues: write, pull-requests: write`, which is appropriate here.

The single best fix with minimal behavior change is to add a workflow-level `permissions` block directly under the `name:` (before `on:`). This applies to all jobs in the workflow (there is only one job, `stale`). We should not alter any existing steps or the use of `secrets.GITHUB_TOKEN`; we only constrain the token’s permissions. Concretely, edit `.github/workflows/stale.yml` to insert:

```yml
permissions:
  contents: write
  issues: write
  pull-requests: write
```

on new lines between the existing line 1 (`name: Mark stale issues and pull requests`) and line 3 (`on:`). No additional imports or other definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
