### PR TITLE
Add configurable HTTP power-on method

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,11 @@
 | `screen.turnOnOff` | This enable possibility turn the screen ON/OFF, webOS >= 4.0. |
 | `screen.saverOnOff` | This enable possibility turn the screen saver ON/OFF, webOS >= 4.0. |
 | `power{}` | Power object. |
-| `power.broadcastAddress` | Her set network `Broadcast Address`, only if You use VLANS in Your network configuration and Your router/switch support IP Directed Broadcast, default is `255.255.255.255`. |
+| `power.wakeMethod` | Power-on method: `wol` (default) or `http`. Existing configurations continue to use Wake-on-LAN. |
+| `power.broadcastAddress` | Here set the network `Broadcast Address` for Wake-on-LAN, default is `255.255.255.255`. |
+| `power.wakeUrl` | Trusted HTTP or HTTPS endpoint used when `wakeMethod` is `http`. |
+| `power.wakeHttpMethod` | HTTP request method, `POST` (default) or `GET`. |
+| `power.wakeTimeout` | Maximum time to wait for the HTTP endpoint in milliseconds, default is `5000`. |
 | `power.startInput` | This enable possibilty to set default Input/App after Power ON TV. |
 | `power.startInputReference` | Here set the default Input/App reference. |
 | `volume{}` | Volume object. |
@@ -148,6 +152,27 @@
 | `mqtt.auth.user` | Here set the MQTT Broker user. |
 | `mqtt.auth.passwd` | Here set the MQTT Broker password. |
 | `reference` | All can be found in `homebridge_directory/lgwebosTv`, `inputs_xxx` file. |
+
+### Power-on methods
+
+Wake-on-LAN remains the default power-on method. Existing configurations do not need to change, and `power.broadcastAddress` continues to control the WOL broadcast destination.
+
+For network arrangements where the TV cannot receive an ordinary WOL magic packet, the plugin can instead call a trusted HTTP or HTTPS endpoint:
+
+```json
+"power": {
+  "wakeMethod": "http",
+  "wakeUrl": "http://living-room-wake.lan/tv/on",
+  "wakeHttpMethod": "POST",
+  "wakeTimeout": 5000,
+  "startInput": false,
+  "startInputReference": "com.webos.app.home"
+}
+```
+
+`GET` and `POST` are supported. Only a `2xx` response is treated as successful. Redirects, non-`2xx` responses, connection failures and timeouts fail the power-on request without indefinite retries. Power-off continues to use the webOS API.
+
+Use a trusted local endpoint. Do not expose the endpoint unnecessarily or place credentials directly in a URL, because URLs can appear in configuration backups and diagnostic output from other systems. The plugin does not log the configured wake URL.
 
 ### RESTFul Integration
 

--- a/README.md
+++ b/README.md
@@ -162,13 +162,15 @@ For network arrangements where the TV cannot receive an ordinary WOL magic packe
 ```json
 "power": {
   "wakeMethod": "http",
-  "wakeUrl": "http://living-room-wake.lan/tv/on",
+  "wakeUrl": "http://192.168.0.50:8080/tv/on",
   "wakeHttpMethod": "POST",
   "wakeTimeout": 5000,
   "startInput": false,
   "startInputReference": "com.webos.app.home"
 }
 ```
+
+The IP address and port above are examples. Replace them with the actual address and port of the local service that will wake the TV.
 
 `GET` and `POST` are supported. Only a `2xx` response is treated as successful. Redirects, non-`2xx` responses, connection failures and timeouts fail the power-on request without indefinite retries. Power-off continues to use the webOS API.
 

--- a/config.schema.json
+++ b/config.schema.json
@@ -979,10 +979,10 @@
                 "wakeUrl": {
                   "title": "Power On URL",
                   "type": "string",
-                  "placeholder": "http://living-room-wake.lan/tv/on",
+                  "placeholder": "http://192.168.0.50:8080/tv/on",
                   "format": "uri",
                   "pattern": "^https?://",
-                  "description": "Trusted local HTTP or HTTPS endpoint used to power on the TV. Do not include credentials in the URL.",
+                  "description": "Trusted local HTTP or HTTPS endpoint used to power on the TV. Replace the example IP address and port with those of your wake service. Do not include credentials in the URL.",
                   "condition": {
                     "functionBody": "return model.devices[arrayIndices].power.wakeMethod === 'http'"
                   }

--- a/config.schema.json
+++ b/config.schema.json
@@ -946,12 +946,80 @@
               "title": "Power",
               "type": "object",
               "properties": {
+                "wakeMethod": {
+                  "title": "Power On Method",
+                  "type": "string",
+                  "default": "wol",
+                  "description": "Select how the TV is powered on. Wake-on-LAN is the default and preserves existing behaviour.",
+                  "anyOf": [
+                    {
+                      "title": "Wake-on-LAN",
+                      "enum": [
+                        "wol"
+                      ]
+                    },
+                    {
+                      "title": "HTTP Request",
+                      "enum": [
+                        "http"
+                      ]
+                    }
+                  ]
+                },
                 "broadcastAddress": {
                   "title": "Broadcast address",
                   "type": "string",
                   "placeholder": "255.255.255.255",
                   "format": "ipv4",
-                  "description": "Her set network broadcast address, only if You use VLANS in Your network configuration and Your router/switch support IP Directed Broadcast."
+                  "description": "Here set the network broadcast address for Wake-on-LAN. The default is 255.255.255.255.",
+                  "condition": {
+                    "functionBody": "return model.devices[arrayIndices].power.wakeMethod !== 'http'"
+                  }
+                },
+                "wakeUrl": {
+                  "title": "Power On URL",
+                  "type": "string",
+                  "placeholder": "http://living-room-wake.lan/tv/on",
+                  "format": "uri",
+                  "pattern": "^https?://",
+                  "description": "Trusted local HTTP or HTTPS endpoint used to power on the TV. Do not include credentials in the URL.",
+                  "condition": {
+                    "functionBody": "return model.devices[arrayIndices].power.wakeMethod === 'http'"
+                  }
+                },
+                "wakeHttpMethod": {
+                  "title": "HTTP Method",
+                  "type": "string",
+                  "default": "POST",
+                  "description": "HTTP method sent to the power-on endpoint.",
+                  "anyOf": [
+                    {
+                      "title": "POST",
+                      "enum": [
+                        "POST"
+                      ]
+                    },
+                    {
+                      "title": "GET",
+                      "enum": [
+                        "GET"
+                      ]
+                    }
+                  ],
+                  "condition": {
+                    "functionBody": "return model.devices[arrayIndices].power.wakeMethod === 'http'"
+                  }
+                },
+                "wakeTimeout": {
+                  "title": "HTTP Timeout",
+                  "type": "integer",
+                  "default": 5000,
+                  "minimum": 100,
+                  "maximum": 60000,
+                  "description": "Maximum time to wait for the power-on endpoint, in milliseconds.",
+                  "condition": {
+                    "functionBody": "return model.devices[arrayIndices].power.wakeMethod === 'http'"
+                  }
                 },
                 "startInput": {
                   "title": "Default Input",
@@ -967,7 +1035,26 @@
                     "functionBody": "return model.devices[arrayIndices].power.startInput === true"
                   }
                 }
-              }
+              },
+              "allOf": [
+                {
+                  "if": {
+                    "required": [
+                      "wakeMethod"
+                    ],
+                    "properties": {
+                      "wakeMethod": {
+                        "const": "http"
+                      }
+                    }
+                  },
+                  "then": {
+                    "required": [
+                      "wakeUrl"
+                    ]
+                  }
+                }
+              ]
             },
             "volume": {
               "title": "Volume",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,6 @@
   },
   "contributors": [],
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node --test"
   }
 }

--- a/sample-config.json
+++ b/sample-config.json
@@ -61,6 +61,7 @@
                         }
                     ],
                     "power": {
+                        "wakeMethod": "wol",
                         "broadcastAddress": "255.255.255.255",
                         "startInput": false,
                         "startInputReference": "com.webos.app.home"

--- a/src/httpwake.js
+++ b/src/httpwake.js
@@ -1,0 +1,99 @@
+import EventEmitter from 'events';
+
+class HttpWake extends EventEmitter {
+    constructor(config, fetchFn = globalThis.fetch) {
+        super();
+        this.power = config.power ?? {};
+        this.fetch = fetchFn;
+        this.logDebug = config.log?.debug;
+    }
+
+    getRequestOptions() {
+        if (typeof this.power.wakeUrl !== 'string' || this.power.wakeUrl.length === 0) {
+            throw new Error(`HTTP wake requires power.wakeUrl.`);
+        }
+
+        let url;
+        try {
+            url = new URL(this.power.wakeUrl);
+        } catch {
+            throw new Error(`HTTP wake requires a valid power.wakeUrl.`);
+        }
+
+        if (!['http:', 'https:'].includes(url.protocol)) {
+            throw new Error(`HTTP wake only supports HTTP and HTTPS URLs.`);
+        }
+
+        if (url.username || url.password) {
+            throw new Error(`HTTP wake URL must not include credentials.`);
+        }
+
+        const configuredMethod = this.power.wakeHttpMethod ?? 'POST';
+        const method = typeof configuredMethod === 'string' ? configuredMethod.toUpperCase() : '';
+        if (!['GET', 'POST'].includes(method)) {
+            throw new Error(`HTTP wake only supports GET and POST requests.`);
+        }
+
+        const timeout = this.power.wakeTimeout ?? 5000;
+        if (!Number.isInteger(timeout) || timeout < 100 || timeout > 60000) {
+            throw new Error(`HTTP wake timeout must be an integer between 100 and 60000 milliseconds.`);
+        }
+
+        if (typeof this.fetch !== 'function') {
+            throw new Error(`HTTP wake is not supported by this Node.js runtime.`);
+        }
+
+        return { url, method, timeout };
+    }
+
+    async wake() {
+        const { url, method, timeout } = this.getRequestOptions();
+        const abortController = new AbortController();
+        let timeoutId;
+
+        try {
+            const timeoutPromise = new Promise((_, reject) => {
+                timeoutId = setTimeout(() => {
+                    abortController.abort();
+                    reject(new Error(`HTTP wake request timed out after ${timeout} milliseconds.`));
+                }, timeout);
+            });
+
+            const response = await Promise.race([
+                this.fetch(url, {
+                    method,
+                    redirect: 'manual',
+                    signal: abortController.signal
+                }),
+                timeoutPromise
+            ]);
+
+            if (!response || !Number.isInteger(response.status)) {
+                throw new Error(`HTTP wake request returned an invalid response.`);
+            }
+
+            try {
+                if (response.body?.cancel) await response.body.cancel();
+            } catch {
+                // The response body is irrelevant to the wake result.
+            }
+
+            if (response.status < 200 || response.status >= 300) {
+                throw new Error(`HTTP wake request failed with status ${response.status}.`);
+            }
+
+            if (this.logDebug) this.emit('debug', `HTTP wake ${method} succeeded with status ${response.status}.`);
+            return true;
+        } catch (error) {
+            if (error.message?.startsWith('HTTP wake')) throw error;
+
+            const code = error.cause?.code;
+            const safeCode = typeof code === 'string' && /^[A-Z0-9_]+$/i.test(code) ? ` (${code})` : '';
+            throw new Error(`HTTP wake request failed to connect${safeCode}.`);
+        } finally {
+            clearTimeout(timeoutId);
+        }
+    }
+}
+
+export default HttpWake;

--- a/src/lgwebosdevice.js
+++ b/src/lgwebosdevice.js
@@ -1,5 +1,5 @@
 import EventEmitter from 'events';
-import WakeOnLan from './wol.js';
+import WakeController from './wakecontroller.js';
 import LgWebOsSocket from './lgwebossocket.js';
 import Functions from './functions.js';
 import { ApiUrls, SystemApps, PictureModes, SoundModes, SoundOutputs, PowerOnWaitAttempts } from './constants.js';
@@ -132,7 +132,7 @@ class LgWebOsDevice extends EventEmitter {
                 case 'Power':
                     switch (value) {
                         case true:
-                            set = !this.power ? await this.wol.wakeOnLan() : true;
+                            set = !this.power ? await this.wakeController.wake() : true;
                             break;
                         case false:
                             cid = await this.lgWebOsSocket.getCid('Power');
@@ -481,7 +481,7 @@ class LgWebOsDevice extends EventEmitter {
                                 case 1:
                                     this.isBooting = true;
 
-                                    await this.wol.wakeOnLan();
+                                    await this.wakeController.wake();
 
                                     if (this.startInput) {
                                         (async () => {
@@ -1403,13 +1403,14 @@ class LgWebOsDevice extends EventEmitter {
 
     //start
     async start() {
-        //Wake On Lan
+        //Power wake controller
         try {
-            this.wol = new WakeOnLan(this.device)
+            this.wakeController = new WakeController(this.device)
                 .on('debug', (debug) => this.emit('debug', debug))
                 .on('error', (error) => this.emit('error', error));
         } catch (error) {
-            if (this.logWarn) this.emit('warn', `Wake On Lan start error: ${error}`);
+            this.wakeController = { wake: async () => { throw error; } };
+            if (this.logWarn) this.emit('warn', `Power wake controller start error: ${error}`);
         }
 
         try {

--- a/src/wakecontroller.js
+++ b/src/wakecontroller.js
@@ -1,0 +1,31 @@
+import EventEmitter from 'events';
+import HttpWake from './httpwake.js';
+import WakeOnLan from './wol.js';
+
+class WakeController extends EventEmitter {
+    constructor(config, handlers = {}) {
+        super();
+
+        const configuredWakeMethod = config.power?.wakeMethod ?? 'wol';
+        const wakeMethod = typeof configuredWakeMethod === 'string' ? configuredWakeMethod.toLowerCase() : '';
+        switch (wakeMethod) {
+            case 'wol':
+                this.wakeHandler = handlers.wol ?? new WakeOnLan(config);
+                break;
+            case 'http':
+                this.wakeHandler = handlers.http ?? new HttpWake(config);
+                break;
+            default:
+                throw new Error(`Unsupported power wake method: ${wakeMethod}.`);
+        }
+
+        this.wakeHandler.on?.('debug', (debug) => this.emit('debug', debug));
+        this.wakeHandler.on?.('error', (error) => this.emit('error', error));
+    }
+
+    async wake() {
+        return this.wakeHandler.wake();
+    }
+}
+
+export default WakeController;

--- a/src/wol.js
+++ b/src/wol.js
@@ -10,7 +10,7 @@ class WakeOnLan extends EventEmitter {
         this.logDebug = config.log?.debug;
     }
 
-    async wakeOnLan() {
+    async wake() {
         return new Promise((resolve, reject) => {
             try {
                 // Parse MAC once
@@ -59,10 +59,13 @@ class WakeOnLan extends EventEmitter {
             }
         });
     }
+
+    async wakeOnLan() {
+        return this.wake();
+    }
 }
 
 export default WakeOnLan;
-
 
 
 

--- a/test/config-schema.test.js
+++ b/test/config-schema.test.js
@@ -1,0 +1,13 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+test('configuration schema defaults to WOL and requires a URL for HTTP wake', async () => {
+    const schema = JSON.parse(await readFile(new URL('../config.schema.json', import.meta.url), 'utf8'));
+    const power = schema.schema.properties.devices.items.properties.power;
+
+    assert.equal(power.properties.wakeMethod.default, 'wol');
+    assert.deepEqual(power.properties.wakeHttpMethod.anyOf.flatMap(option => option.enum), ['POST', 'GET']);
+    assert.equal(power.properties.wakeTimeout.default, 5000);
+    assert.deepEqual(power.allOf[0].then.required, ['wakeUrl']);
+});

--- a/test/httpwake.test.js
+++ b/test/httpwake.test.js
@@ -1,0 +1,104 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import HttpWake from '../src/httpwake.js';
+
+const config = (power = {}) => ({
+    power: {
+        wakeMethod: 'http',
+        wakeUrl: 'http://living-room-wake.lan/tv/on',
+        ...power
+    }
+});
+
+test('HTTP wake defaults to POST and accepts a 2xx response', async () => {
+    let request;
+    const fetchFn = async (url, options) => {
+        request = { url, options };
+        return { status: 204 };
+    };
+
+    const result = await new HttpWake(config(), fetchFn).wake();
+
+    assert.equal(result, true);
+    assert.equal(request.url.href, 'http://living-room-wake.lan/tv/on');
+    assert.equal(request.options.method, 'POST');
+    assert.equal(request.options.redirect, 'manual');
+});
+
+test('HTTP wake supports GET', async () => {
+    let method;
+    const fetchFn = async (url, options) => {
+        method = options.method;
+        return { status: 200 };
+    };
+
+    await new HttpWake(config({ wakeHttpMethod: 'GET' }), fetchFn).wake();
+
+    assert.equal(method, 'GET');
+});
+
+test('HTTP wake rejects non-2xx responses without retrying', async () => {
+    let calls = 0;
+    const fetchFn = async () => {
+        calls++;
+        return { status: 503 };
+    };
+
+    await assert.rejects(
+        new HttpWake(config(), fetchFn).wake(),
+        /failed with status 503/
+    );
+    assert.equal(calls, 1);
+});
+
+test('HTTP wake does not follow redirects', async () => {
+    let redirect;
+    const fetchFn = async (url, options) => {
+        redirect = options.redirect;
+        return { status: 302 };
+    };
+
+    await assert.rejects(new HttpWake(config(), fetchFn).wake(), /failed with status 302/);
+    assert.equal(redirect, 'manual');
+});
+
+test('HTTP wake times out cleanly', async () => {
+    const fetchFn = async () => new Promise(() => {});
+
+    await assert.rejects(
+        new HttpWake(config({ wakeTimeout: 100 }), fetchFn).wake(),
+        /timed out after 100 milliseconds/
+    );
+});
+
+test('HTTP wake reports connection errors without exposing the URL', async () => {
+    const fetchFn = async () => {
+        const error = new TypeError('fetch failed for http://user:secret@living-room-wake.lan/tv/on');
+        error.cause = { code: 'ECONNREFUSED' };
+        throw error;
+    };
+
+    await assert.rejects(
+        new HttpWake(config(), fetchFn).wake(),
+        (error) => {
+            assert.match(error.message, /failed to connect \(ECONNREFUSED\)/);
+            assert.doesNotMatch(error.message, /user|secret|living-room/);
+            return true;
+        }
+    );
+});
+
+test('HTTP wake rejects incomplete or invalid configuration before requesting', async () => {
+    let calls = 0;
+    const fetchFn = async () => {
+        calls++;
+        return { status: 200 };
+    };
+
+    await assert.rejects(new HttpWake(config({ wakeUrl: undefined }), fetchFn).wake(), /requires power\.wakeUrl/);
+    await assert.rejects(new HttpWake(config({ wakeUrl: 'file:///tmp/wake' }), fetchFn).wake(), /only supports HTTP and HTTPS/);
+    await assert.rejects(new HttpWake(config({ wakeUrl: 'http://user:secret@living-room-wake.lan/tv/on' }), fetchFn).wake(), /must not include credentials/);
+    await assert.rejects(new HttpWake(config({ wakeHttpMethod: 'DELETE' }), fetchFn).wake(), /only supports GET and POST/);
+    await assert.rejects(new HttpWake(config({ wakeTimeout: 0 }), fetchFn).wake(), /timeout must be an integer/);
+    assert.equal(calls, 0);
+});

--- a/test/httpwake.test.js
+++ b/test/httpwake.test.js
@@ -5,7 +5,7 @@ import HttpWake from '../src/httpwake.js';
 const config = (power = {}) => ({
     power: {
         wakeMethod: 'http',
-        wakeUrl: 'http://living-room-wake.lan/tv/on',
+        wakeUrl: 'http://192.168.0.50:8080/tv/on',
         ...power
     }
 });
@@ -20,7 +20,7 @@ test('HTTP wake defaults to POST and accepts a 2xx response', async () => {
     const result = await new HttpWake(config(), fetchFn).wake();
 
     assert.equal(result, true);
-    assert.equal(request.url.href, 'http://living-room-wake.lan/tv/on');
+    assert.equal(request.url.href, 'http://192.168.0.50:8080/tv/on');
     assert.equal(request.options.method, 'POST');
     assert.equal(request.options.redirect, 'manual');
 });
@@ -73,7 +73,7 @@ test('HTTP wake times out cleanly', async () => {
 
 test('HTTP wake reports connection errors without exposing the URL', async () => {
     const fetchFn = async () => {
-        const error = new TypeError('fetch failed for http://user:secret@living-room-wake.lan/tv/on');
+        const error = new TypeError('fetch failed for http://user:secret@192.168.0.50:8080/tv/on');
         error.cause = { code: 'ECONNREFUSED' };
         throw error;
     };
@@ -82,7 +82,7 @@ test('HTTP wake reports connection errors without exposing the URL', async () =>
         new HttpWake(config(), fetchFn).wake(),
         (error) => {
             assert.match(error.message, /failed to connect \(ECONNREFUSED\)/);
-            assert.doesNotMatch(error.message, /user|secret|living-room/);
+            assert.doesNotMatch(error.message, /user|secret|192\.168\.0\.50/);
             return true;
         }
     );
@@ -97,7 +97,7 @@ test('HTTP wake rejects incomplete or invalid configuration before requesting', 
 
     await assert.rejects(new HttpWake(config({ wakeUrl: undefined }), fetchFn).wake(), /requires power\.wakeUrl/);
     await assert.rejects(new HttpWake(config({ wakeUrl: 'file:///tmp/wake' }), fetchFn).wake(), /only supports HTTP and HTTPS/);
-    await assert.rejects(new HttpWake(config({ wakeUrl: 'http://user:secret@living-room-wake.lan/tv/on' }), fetchFn).wake(), /must not include credentials/);
+    await assert.rejects(new HttpWake(config({ wakeUrl: 'http://user:secret@192.168.0.50:8080/tv/on' }), fetchFn).wake(), /must not include credentials/);
     await assert.rejects(new HttpWake(config({ wakeHttpMethod: 'DELETE' }), fetchFn).wake(), /only supports GET and POST/);
     await assert.rejects(new HttpWake(config({ wakeTimeout: 0 }), fetchFn).wake(), /timeout must be an integer/);
     assert.equal(calls, 0);

--- a/test/wakecontroller.test.js
+++ b/test/wakecontroller.test.js
@@ -1,0 +1,80 @@
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+import LgWebOsDevice from '../src/lgwebosdevice.js';
+import WakeController from '../src/wakecontroller.js';
+
+class WakeHandler extends EventEmitter {
+    constructor() {
+        super();
+        this.calls = 0;
+    }
+
+    async wake() {
+        this.calls++;
+        return true;
+    }
+}
+
+const deviceConfig = (power = {}) => ({
+    name: 'Test TV',
+    host: '192.0.2.10',
+    mac: 'ab:cd:ef:fe:dc:ba',
+    displayType: 1,
+    inputs: {},
+    buttons: [],
+    sensors: [],
+    sound: { modes: [], outputs: [] },
+    picture: { modes: [] },
+    power
+});
+
+test('existing configurations default to WOL and make no HTTP request', async () => {
+    const wol = new WakeHandler();
+    const http = new WakeHandler();
+    const controller = new WakeController(deviceConfig(), { wol, http });
+
+    assert.equal(await controller.wake(), true);
+    assert.equal(wol.calls, 1);
+    assert.equal(http.calls, 0);
+});
+
+test('HTTP configurations invoke only the HTTP wake handler', async () => {
+    const wol = new WakeHandler();
+    const http = new WakeHandler();
+    const controller = new WakeController(deviceConfig({ wakeMethod: 'http' }), { wol, http });
+
+    assert.equal(await controller.wake(), true);
+    assert.equal(wol.calls, 0);
+    assert.equal(http.calls, 1);
+});
+
+test('external integration power-on uses the configured wake controller', async () => {
+    const api = {
+        platformAccessory: class {},
+        hap: {
+            Characteristic: {},
+            Service: {},
+            Categories: {},
+            encode: {},
+            uuid: {}
+        }
+    };
+    const device = new LgWebOsDevice(api, deviceConfig(), '', '', '', '', '', '');
+    const wakeController = new WakeHandler();
+    device.wakeController = wakeController;
+
+    assert.equal(await device.setOverExternalIntegration('RESTFul', 'Power', true), true);
+    assert.equal(wakeController.calls, 1);
+});
+
+test('all device power-on paths use the wake controller and UUID stays MAC-based', async () => {
+    const source = await readFile(new URL('../src/lgwebosdevice.js', import.meta.url), 'utf8');
+    const wakeCalls = source.match(/this\.wakeController\.wake\(\)/g) ?? [];
+
+    assert.equal(wakeCalls.length, 2);
+    assert.doesNotMatch(source, /this\.wol\.wakeOnLan\(\)/);
+    assert.match(source, /AccessoryUUID\.generate\(this\.mac\)/);
+    assert.doesNotMatch(source, /AccessoryUUID\.generate\([^)]*wake/i);
+});


### PR DESCRIPTION
## Problem

The plugin currently uses ordinary Wake-on-LAN for every power-on request. Some network arrangements cannot deliver a usable WOL packet to the television, even though normal webOS control works correctly once the television is running.

## Proposed solution

Add a small wake-controller abstraction with two power-on implementations:

- Wake-on-LAN, preserving the existing behaviour
- An optional HTTP or HTTPS request to a trusted local endpoint

The HTTP method supports GET and POST, uses a finite configurable timeout, accepts only 2xx responses and does not follow redirects.

All existing power-on paths now use the configured wake controller. Power-off continues to use the existing webOS API.

## Backward compatibility

Wake-on-LAN remains the default when `power.wakeMethod` is omitted.

No existing configuration needs to change. The existing `mac` setting, broadcast-address behaviour and HomeKit accessory UUID generation remain unchanged.

## Configuration example

```json
{
  "power": {
    "wakeMethod": "http",
    "wakeUrl": "http://192.168.0.50:8080/tv/on",
    "wakeHttpMethod": "POST",
    "wakeTimeout": 5000,
    "startInput": false,
    "startInputReference": "com.webos.app.home"
  }
}
```

The IP address and port above are examples. Replace them with the actual address and port of the local service that will wake the TV.

## Testing completed

- Added a proportionate test foundation using Node's built-in test runner
- 12 automated tests pass
- Tested WOL default selection and HTTP selection
- Tested GET, POST, 2xx success, non-2xx failure, redirects, timeout and connection failure
- Tested invalid and incomplete HTTP configuration
- Verified WOL configurations do not make HTTP requests
- Verified both power-on paths use the wake controller
- Verified accessory UUID generation remains MAC-based
- JavaScript syntax checks passed
- Configuration and package JSON parsing passed
- `npm ls --depth=0` passed
- `npm pack --dry-run` passed
- Production dependency audit reports zero vulnerabilities

## Security considerations

- Only HTTP and HTTPS URLs are accepted
- GET and POST are the only supported methods
- URL credentials are rejected
- The configured URL is not written to plugin logs
- Redirects are not followed
- Requests use a finite timeout and are not retried indefinitely
- No command execution or request-body configuration has been added

Wake-on-LAN remains the default and existing configurations require no changes.

Closes #313